### PR TITLE
Storage Proxy supports item removal

### DIFF
--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -29,7 +29,13 @@ const createAccessor = (name, data)=>(
       setItem(name, data)
       // Return true to accept the changes
       return true
-    }
+    },
+    // Refer to above comments
+    deleteProperty(){
+      Reflect.deleteProperty(...arguments)
+      setItem(name, data)
+      return true
+    },
   })
 )
 


### PR DESCRIPTION
This is needed for array.splice() and others to work well.